### PR TITLE
fix(bridge): hide dock icon on macOS for tray-only app

### DIFF
--- a/apps/bridge/src-tauri/Info.plist
+++ b/apps/bridge/src-tauri/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>LSUIElement</key>
+    <true/>
+</dict>
+</plist>

--- a/apps/bridge/src-tauri/src/lib.rs
+++ b/apps/bridge/src-tauri/src/lib.rs
@@ -558,6 +558,12 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_updater::Builder::new().build())
         .setup(|app| {
+            // Hide dock icon on macOS (tray-only app)
+            #[cfg(target_os = "macos")]
+            {
+                app.set_activation_policy(tauri::ActivationPolicy::Accessory);
+            }
+
             let cfg = config::load_config(app.handle());
             let port = cfg.server.port;
             let autostart_enabled = cfg.features.enable_autostart;

--- a/apps/bridge/src-tauri/tauri.conf.json
+++ b/apps/bridge/src-tauri/tauri.conf.json
@@ -50,7 +50,8 @@
     },
     "macOS": {
       "signingIdentity": "-",
-      "minimumSystemVersion": "10.13"
+      "minimumSystemVersion": "10.13",
+      "infoPlist": "Info.plist"
     }
   },
   "plugins": {


### PR DESCRIPTION
 - Fixed macOS dock icon appearing for tray-only app by adding LSUIElement: true to the bundle config