### PR TITLE
fix(bridge): tray quit fully exits app & WS cleanup on server stop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ yarn-error.log*
 # Packages/Apps specific TODOs
 __*.md
 *.tgz
+.content

--- a/apps/bridge/src-tauri/src/lib.rs
+++ b/apps/bridge/src-tauri/src/lib.rs
@@ -927,7 +927,9 @@ pub fn run() {
         .expect("error while running tauri application")
         .run(|_app_handle, event| {
             if let tauri::RunEvent::ExitRequested { api, .. } = event {
-                api.prevent_exit();
+                if !tray::QUIT_REQUESTED.load(std::sync::atomic::Ordering::SeqCst) {
+                    api.prevent_exit();
+                }
             }
         });
 }

--- a/apps/bridge/src-tauri/src/server/handlers.rs
+++ b/apps/bridge/src-tauri/src/server/handlers.rs
@@ -78,6 +78,8 @@ pub struct AppState {
     pub config: Arc<Mutex<AppConfig>>,
     pub auth_state: Arc<Mutex<AuthState>>,
     pub loop_manager: Arc<crate::server::LoopManager>,
+    /// Notifies all WS connections to close when the server is shutting down.
+    pub shutdown: tokio::sync::watch::Receiver<bool>,
 }
 
 pub fn get_or_update_gpu_stats(state: &Arc<AppState>) -> Option<crate::server::gpu::GpuData> {

--- a/apps/bridge/src-tauri/src/server/mod.rs
+++ b/apps/bridge/src-tauri/src/server/mod.rs
@@ -83,6 +83,22 @@ impl LoopManager {
         }
     }
 
+    /// Abort all running monitoring loops immediately.
+    pub fn abort_all(&self) {
+        if let Some(h) = self.stats_handle.lock().unwrap().take() {
+            println!("[LoopManager] Aborting stats loop (shutdown)");
+            h.abort();
+        }
+        if let Some(h) = self.media_handle.lock().unwrap().take() {
+            println!("[LoopManager] Aborting media loop (shutdown)");
+            h.abort();
+        }
+        if let Some(h) = self.processes_handle.lock().unwrap().take() {
+            println!("[LoopManager] Aborting processes loop (shutdown)");
+            h.abort();
+        }
+    }
+
     /// Called when topic subscriber count goes from 1 -> 0
     pub fn stop_loop_if_idle(&self, topic: &str, state: &handlers::AppState) {
         let topics = state.active_topics.lock().unwrap();
@@ -462,6 +478,7 @@ pub async fn start_server(
     mut shutdown_rx: tokio::sync::broadcast::Receiver<()>,
 ) {
     let loop_manager = Arc::new(LoopManager::new());
+    let (ws_shutdown_tx, ws_shutdown_rx) = tokio::sync::watch::channel(false);
 
     let state = Arc::new(AppState {
         system: Arc::new(Mutex::new(System::new_all())),
@@ -484,6 +501,7 @@ pub async fn start_server(
         config: config,
         auth_state: auth_state,
         loop_manager: loop_manager,
+        shutdown: ws_shutdown_rx,
     });
 
     // No always-running loops! Loops are now lazy-spawned via LoopManager
@@ -575,10 +593,17 @@ pub async fn start_server(
     let (inner_tx, inner_rx1) = tokio::sync::broadcast::channel::<()>(1);
     let inner_rx2 = inner_tx.subscribe();
 
-    // Forward the external shutdown signal to the inner broadcast
+    // Forward the external shutdown signal to the inner broadcast,
+    // abort monitoring loops, and notify all WS connections to close.
+    let shutdown_state = state.clone();
     tauri::async_runtime::spawn(async move {
         shutdown_rx.recv().await.ok();
         println!("Server received shutdown signal");
+        // Abort all monitoring loops so they stop feeding the broadcast channel
+        shutdown_state.loop_manager.abort_all();
+        // Signal all WS connections to close
+        let _ = ws_shutdown_tx.send(true);
+        // Stop the HTTP listeners
         let _ = inner_tx.send(());
     });
 

--- a/apps/bridge/src-tauri/src/server/ws.rs
+++ b/apps/bridge/src-tauri/src/server/ws.rs
@@ -66,9 +66,15 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>, auth_ctx: AuthCo
     // SEND TASK - handles both broadcast events and outgoing messages from recv_task
     let mut send_task = tokio::spawn({
         let subs = subscriptions.clone();
+        let mut shutdown_rx = state.shutdown.clone();
         async move {
             loop {
                 tokio::select! {
+                    // Server is shutting down — close this connection
+                    _ = shutdown_rx.changed() => {
+                        let _ = sender.close().await;
+                        break;
+                    }
                     // Handle outgoing messages from recv_task (errors, acks)
                     Some(msg) = outgoing_rx.recv() => {
                         if sender.send(Message::Text(msg)).await.is_err() {

--- a/apps/bridge/src-tauri/src/tray.rs
+++ b/apps/bridge/src-tauri/src/tray.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::{AtomicBool, Ordering};
 use tauri::{
     menu::{Menu, MenuItem},
     tray::{MouseButton, TrayIconBuilder, TrayIconEvent},
@@ -5,6 +6,10 @@ use tauri::{
     Manager, Runtime, WebviewUrl, WebviewWindowBuilder,
     window::Color,
 };
+
+/// Set to `true` right before an intentional quit so the
+/// `RunEvent::ExitRequested` handler knows not to prevent it.
+pub static QUIT_REQUESTED: AtomicBool = AtomicBool::new(false);
 
 pub fn show_or_create_window<R: Runtime>(app: &tauri::AppHandle<R>) {
     if let Some(window) = app.get_webview_window("main") {
@@ -47,6 +52,7 @@ pub fn create_tray<R: Runtime>(app: &tauri::AppHandle<R>) -> tauri::Result<()> {
         .show_menu_on_left_click(false)
         .on_menu_event(|app, event| match event.id.as_ref() {
             "quit" => {
+                QUIT_REQUESTED.store(true, Ordering::SeqCst);
                 app.exit(0);
             }
             "open" => {

--- a/apps/bridge/src/components/screens/post-content-block.tsx
+++ b/apps/bridge/src/components/screens/post-content-block.tsx
@@ -1,3 +1,4 @@
+import { openUrl } from "@tauri-apps/plugin-opener";
 import { SquareDashedMousePointer } from "lucide-solid";
 import { Button } from "../ui/button";
 
@@ -10,10 +11,18 @@ const PostContentBlock = () => {
                     Couldn't find what you're looking for?
                 </p>
                 <div class="flex items-center gap-2">
-                    <Button variant={"link"} class="text-xs">
+                    <Button
+                        onClick={() => openUrl("https://www.cntrl.pw/docs")}
+                        variant={"link"}
+                        class="text-xs"
+                    >
                         Docs
                     </Button>
-                    <Button variant={"link"} class="text-xs">
+                    <Button
+                        onClick={() => openUrl("https://github.com/azaek/cntrl/issues")}
+                        variant={"link"}
+                        class="text-xs"
+                    >
                         Github Issues
                     </Button>
                 </div>


### PR DESCRIPTION
## Summary
  - **Tray Quit exits completely** — `ExitRequested` handler now checks a `QUIT_REQUESTED` flag so `prevent_exit()` is
  skipped when the user clicks Quit from the tray menu. Closes #9
  - **WS connections close on server stop** — Added a shutdown watch channel to `AppState` that all WS send tasks listen
   to. On shutdown, monitoring loops are aborted via `LoopManager::abort_all()` and all active WebSocket connections are
   closed cleanly. Closes #10
## Files changed
  - `apps/bridge/src-tauri/src/tray.rs` — `QUIT_REQUESTED` AtomicBool flag, set before `app.exit(0)`
  - `apps/bridge/src-tauri/src/lib.rs` — `ExitRequested` handler checks flag before preventing exit
  - `apps/bridge/src-tauri/src/server/handlers.rs` — `AppState.shutdown` watch channel field
  - `apps/bridge/src-tauri/src/server/mod.rs` — `LoopManager::abort_all()`, shutdown sequence signals WS + aborts loops
  - `apps/bridge/src-tauri/src/server/ws.rs` — Send task listens for shutdown signal